### PR TITLE
Add support for proxy settings

### DIFF
--- a/lib/trademe/authentication.rb
+++ b/lib/trademe/authentication.rb
@@ -1,15 +1,15 @@
 module Trademe
   module Authentication
-    
+
     attr_accessor :consumer, :request_token, :access_token
 
     # authorize_url EG: "https://secure.trademe.co.nz/Oauth/Authorize?oauth_token=50277019F3C05999C6599D6801C4607F73"
-    def generate_request_token(callback, key, secret)
-      generate_consumer(key, secret)
+    def generate_request_token(callback, key, secret, options={})
+      generate_consumer(key, secret, options)
       @request_token = @consumer.get_request_token :oauth_callback => callback
       @request_token.authorize_url
     end
-    
+
     def generate_access_token(consumer_key, consumer_secret, access_key, access_secret)
       generate_consumer(consumer_key, consumer_secret)
       @access_token = OAuth::AccessToken.new(@consumer, access_key, access_secret)
@@ -25,14 +25,14 @@ module Trademe
     def authorized?
       !!consumer && !!access_token
     end
-    
-    def generate_consumer(key, secret)
-      @consumer = OAuth::Consumer.new(key, secret, { 
+
+    def generate_consumer(key, secret, options={})
+      @consumer = OAuth::Consumer.new(key, secret, {
         :site               => "https://secure.trademe.co.nz",
         :request_token_path => "/Oauth/RequestToken",
         :access_token_path  => "/Oauth/AccessToken",
         :authorize_path     => "/Oauth/Authorize"
-      })
+      }.merge(options))
     end
   end
 end


### PR DESCRIPTION
Clients that are behind a proxy server can now pass their proxy settings through to the oauth library calls
